### PR TITLE
use HashRouter to allow IPFS hosting to work

### DIFF
--- a/projects/Juno tool/index.json
+++ b/projects/Juno tool/index.json
@@ -5,5 +5,5 @@
     "state": 1,
     "twitter_link": "twitter.com",
     "tg_link": "t.me",
-    "address": "0XAAAAAAAAA
+    "address": "0XAAAAAAAAA"
 }

--- a/public/index.html
+++ b/public/index.html
@@ -19,9 +19,9 @@
     <meta property="og:image:alt" content="Juno | Smart Contract Zone"/>
     <meta content="Juno | Smart Contract Zone" property="og:title">
 
-    <link href="/manifest.json" rel="manifest">
-    <link href="/favicon.ico" rel="shortcut icon">
-    <link href="/assets/logos/logo_192x192.png" rel="apple-touch-icon">
+    <link href="./manifest.json" rel="manifest">
+    <link href="./favicon.ico" rel="shortcut icon">
+    <link href="./assets/logos/logo_192x192.png" rel="apple-touch-icon">
 
     <meta content="private" http-equiv="Cache-Control"/>
     <meta content="86400000" http-equiv="Expires"/>

--- a/src/containers/Dashboard/Section1/index.js
+++ b/src/containers/Dashboard/Section1/index.js
@@ -27,7 +27,7 @@ const Section1 = (props) => {
                 <Link className="get_started_button" href="https://docs.junochain.com/" rel="noopener" target="_blank">
                     {variables[props.lang].start_building}
                 </Link>
-                <Link className="get_started_button" href="/ecosystem">
+                <Link className="get_started_button" href="#/ecosystem">
                     {variables[props.lang].ecosystem}
                 </Link>
             </div>

--- a/src/containers/Ecosystem/Ecosystem.provider.js
+++ b/src/containers/Ecosystem/Ecosystem.provider.js
@@ -8,8 +8,8 @@ export const useEcosystem = () => useContext(EcosystemContext);
 
 const getRepoURL = () => 'https://api.github.com/repos/CosmosContracts/website/git/trees/main';
 const getTreeRepoUrl = (sha) => `https://api.github.com/repos/CosmosContracts/website/git/trees/${sha}`;
-const getJsonURL = (name) => `https://raw.githubusercontent.com/CosmosContracts/website/main/projects/${name}/index.json`;
-const getImageURL = (name, image) => `https://raw.githubusercontent.com/CosmosContracts/website/main/projects/${name}/${image}`;
+const getJsonURL = (name) => `https://raw.githubusercontent.com/CosmosContracts/website/main/projects/${encodeURIComponent(name)}/index.json`;
+const getImageURL = (name, image) => `https://raw.githubusercontent.com/CosmosContracts/website/main/projects/${encodeURIComponent(name)}/${encodeURIComponent(image)}`;
 
 const get = (url) => {
     const options = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import reducer from './reducers';
@@ -20,9 +20,9 @@ const store = createStore(
 
 const app = (
     <Provider store={store}>
-        <BrowserRouter>
+        <Router >
             <Route component={App}/>
-        </BrowserRouter>
+        </Router>
     </Provider>
 );
 


### PR DESCRIPTION
According to the internet, using HashRouter is necessary to allow IPFS hosting to work, because otherwise IPFS would try to find the physical "ecosystem" when navigating to "/ecosystem" and fail. The downside is a '#' is present in the URL. Example:
https://ipfs.io/ipfs/QmX5DrWnuvRHJCmbj9jxJPYLEuAAQHjUgS8cToQwF18mV3

If we want to continue to use IPFS, we can try and get this merged. If we want to host elsewhere e.g. on Akash, we can disregard this PR. The server will need to be configured to continue to serve index.html regardless of the route.