### PR TITLE
Use reduced ecosystem video

### DIFF
--- a/src/pages/ecosystem.js
+++ b/src/pages/ecosystem.js
@@ -2,8 +2,8 @@ import * as React from "react"
 import {AnchorLink} from "gatsby-plugin-anchor-links";
 import Layout from "../components/layout";
 import Ecosystem from "../components/ecosystem";
-import EcosystemVideoMov from "../videos/ecosystem.mp4";
-import EcosystemVideo from "../videos/ecosystem.webm";
+import EcosystemVideoMov from "../videos/ecosystem-small.mp4";
+import EcosystemVideo from "../videos/ecosystem-small.webm";
 import EcosystemPoster from "../videos/ecosystem.png";
 import {useState, useEffect} from "react";
 
@@ -91,7 +91,7 @@ const EcosystemPage = (props) => {
                                 <h5 className={'mb-3 mb-lg-4 mb-xl-5'}
                                     data-sal="fade"
                                     data-sal-delay="200"
-                                    data-sal-duration="1000">Browse Juno ecosystem
+                                    data-sal-duration="1000">Browse Juno Ecosystem
                                 </h5>
                             </div>
                             <div className={'col-12 col-md-auto'}>

--- a/src/pages/grants.js
+++ b/src/pages/grants.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import Layout from "../components/layout";
-import EcosystemVideoMov from "../videos/ecosystem.mp4";
-import EcosystemVideo from "../videos/ecosystem.webm";
+import EcosystemVideoMov from "../videos/ecosystem-small.mp4";
+import EcosystemVideo from "../videos/ecosystem-small.webm";
 import EcosystemPoster from "../videos/ecosystem.png";
 import {useState, useEffect} from "react";
 

--- a/src/sections/ecosystem-section.js
+++ b/src/sections/ecosystem-section.js
@@ -1,8 +1,8 @@
 import React from "react";
 import {Link} from "gatsby";
-import EcosystemVideo from "../videos/ecosystem.webm";
+import EcosystemVideoMov from "../videos/ecosystem-small.mp4";
+import EcosystemVideo from "../videos/ecosystem-small.webm";
 import EcosystemPoster from "../videos/ecosystem.png";
-import EcosystemVideoMov from "../videos/ecosystem.mp4";
 import {useState, useEffect} from "react";
 
 const menu = require('../contents/urls.json');


### PR DESCRIPTION
- [x] Replaced ecosystem videos by the reduced ones, present in `ecosystem section`, `ecosystem page`, and `grants page`.
   - 13 times less size if non Safari.
   - 4 times less size if Safari.

_Would be helpful if we can reduce `hero.mp4` and `hero.webm`._

This PR should lower video bandwidth consumption.