### PR TITLE
Fix crash when visiting /ecosystem/#browse

### DIFF
--- a/src/pages/ecosystem.js
+++ b/src/pages/ecosystem.js
@@ -16,8 +16,11 @@ function toggleNav(){
 }
 
 function loadTab(props){
-    const currentCategory = props.location.hash ? props.location.hash.substring(1) : 'all';
-    document.getElementById('nav-'+currentCategory+'-tab').click();
+    const hashtag = window.location.hash
+    if (!hashtag) {
+        const currentCategory = props.location.hash ? props.location.hash.substring(1) : 'all';
+        document.getElementById('nav-'+currentCategory+'-tab').click();
+    }
 }
 
 const EcosystemPage = (props) => {


### PR DESCRIPTION
- [x] Fixed a bug which caused a crash when `/ecosystem/#browse` is directly visited through browsers.