### PR TITLE
Remove validator comment from Spark description

### DIFF
--- a/src/contents/ecosystems.json
+++ b/src/contents/ecosystems.json
@@ -342,7 +342,7 @@
 },{  
   "icon": "sparkibc-logo.png",
   "title": "Spark IBC",
-  "text": "Rewarding and promoting decentralization and innovation within the Cosmos. Now validating Juno",
+  "text": "Rewarding and promoting decentralization and innovation within the Cosmos.",
   "featured": false,
   "category": "Dapp",
   "website": "https://sparkibc.zone/",


### PR DESCRIPTION
Removing Juno validator comment from Spark IBC description as mentioned in https://github.com/CosmosContracts/website/pull/137.