### PR TITLE
Update Discord URL

### DIFF
--- a/src/contents/urls.json
+++ b/src/contents/urls.json
@@ -3,7 +3,7 @@
   "blog": "https://medium.com/@JunoNetwork",
   "updates": "https://t.me/Juno_Updates",
   "github": "https://github.com/CosmosContracts",
-  "discord": "https://discord.gg/Juno",
+  "discord": "https://discord.junonetwork.io/",
   "get-started": "https://docs.junonetwork.io/juno/readme",
   "ecosystem": "/ecosystem",
   "hacks-and-bounties": "https://medium.com/hack-juno-dao/hack-juno-280670cd71b2",


### PR DESCRIPTION
This PR updates the Discord URL to `https://discord.junonetwork.io/`